### PR TITLE
Add Klaviyo form submit

### DIFF
--- a/custom pixel.js
+++ b/custom pixel.js
@@ -23,7 +23,7 @@ make sure to go through the settings below and change the values where applicabl
 const config = {
     /* *************** CONVERSION TRACKING SETTINGS *************** */
     conversionTracking: {
-        gtmContainerId: 'GTM-N8CVT6L', // replace with your Google Tag Manager container ID
+        gtmContainerId: 'GTM-XXXXXX', // replace with your Google Tag Manager container ID
         // change to false for events that you don't want to be pushed to the data layer:
         trackPageViews: true,
         trackClicks: true,

--- a/custom pixel.js
+++ b/custom pixel.js
@@ -23,7 +23,7 @@ make sure to go through the settings below and change the values where applicabl
 const config = {
     /* *************** CONVERSION TRACKING SETTINGS *************** */
     conversionTracking: {
-        gtmContainerId: 'GTM-XXXXXX', // replace with your Google Tag Manager container ID
+        gtmContainerId: 'GTM-N8CVT6L', // replace with your Google Tag Manager container ID
         // change to false for events that you don't want to be pushed to the data layer:
         trackPageViews: true,
         trackClicks: true,
@@ -38,6 +38,7 @@ const config = {
         trackAddShippingInfo: true,
         trackAddPaymentInfo: true,
         trackPurchase: true,
+        trackKlaviyo: true
     },
 
     /* *************** STORE SETTINGS *************** */
@@ -740,3 +741,15 @@ if (config.conversionTracking.trackPurchase) {
     });
 }
 /* *************** END OF PURCHASE *************** */
+
+/* *************** KLAVIYO *************** */
+if (config.conversionTracking.trackKlaviyo) {
+  analytics.subscribe('klaviyo_form_submitted', (event) => {
+    window.dataLayer.push({
+      event: 'klaviyo_form_submit',
+      formId: event.customData.form_id,
+      formTitle: event.customData.form_title
+    });
+  });
+}
+/* *************** END KLAVIYO *************** */

--- a/gtm-customer-events-storefront.html
+++ b/gtm-customer-events-storefront.html
@@ -1,7 +1,5 @@
-<!-- create a new Snippet called 'gtm-customer-events-storefront' and paste the below code into it -->
-
-<!-- click tracking -->
 <script>
+
     // function that gets the path of the clicked element. Borrowed from Simo Ahava. https://www.simoahava.com/analytics/create-css-path-variable-for-click-element/
    function gtm_get_click_element_path(element) {
     var el = element;
@@ -51,6 +49,15 @@
          click_url : closestLink.href || ''
        })
      }
+  });
+  
+  window.addEventListener('klaviyoForms', function(e) {
+    if (e.detail.type == 'submit'){
+      Shopify.analytics.publish('klaviyo_form_submitted', {
+        form_id: e.detail.formId || null,
+        form_title: e.detail.metaData.$source || null
+      });
+    }
   });
 </script>
 <!-- end of click tracking -->

--- a/gtm-customer-events-storefront.html
+++ b/gtm-customer-events-storefront.html
@@ -1,3 +1,5 @@
+<!-- create a new Snippet called 'gtm-customer-events-storefront' and paste the below code into it -->
+<!-- click and Klaviyo tracking -->
 <script>
 
     // function that gets the path of the clicked element. Borrowed from Simo Ahava. https://www.simoahava.com/analytics/create-css-path-variable-for-click-element/
@@ -60,4 +62,4 @@
     }
   });
 </script>
-<!-- end of click tracking -->
+<!-- end of click and Klaviyo tracking -->


### PR DESCRIPTION
Klaviyo is used by many, if not most e-commerce stores for email- and retention marketing. Since its opt-in forms do not use a standard HTML form submit, the default code is unable to capture Klaviyo form submits. These edits add a listener for Klaviyo events alongside the required datalayer event.